### PR TITLE
u-boot: detect fit configuration naming at runtime

### DIFF
--- a/bisdn/installer/u-boot-arch/install.sh
+++ b/bisdn/installer/u-boot-arch/install.sh
@@ -58,6 +58,7 @@ platform_install_bootloader_entry()
     local blk_dev=$1
     local bisdn_linux_part=$2
     local bisdn_linux_mnt=$3
+    local separator=
 
     if [ -f fitImage ]; then
 	cp fitImage $bisdn_linux_mnt/boot/uImage
@@ -70,7 +71,13 @@ platform_install_bootloader_entry()
 
     machine_fixups
 
-    hw_load_str="$(hw_load $blk_dev $bisdn_linux_part)"
+    if grep -q "kernel@1" $bisdn_linux_mnt/boot/uImage; then
+        separator="@"
+    else
+        separator="-"
+    fi
+
+    hw_load_str="$(hw_load $blk_dev $bisdn_linux_part $separator)"
 
     echo "Updating U-Boot environment variables"
     (cat <<EOF

--- a/bisdn/machine/accton/accton-as4610/platform.conf
+++ b/bisdn/machine/accton/accton-as4610/platform.conf
@@ -77,22 +77,23 @@ machine_fixups() {
 hw_load() {
     local blk_dev=$1
     local bisdn_linux_part=$2
+    local separator=$3
     local platform=$(onie-syseeprom -g 0x21)
 
     bisdn_linux_uuid="$(echo -e "i\n${bisdn_linux_part}\nq" | gdisk $blk_dev | grep "^Partition unique" | awk '{print $4}')"
 
     case "$platform" in
     "4610-30T"*)
-        configuration="#conf@arm-accton-as4610-30t.dtb"
+        configuration="#conf${separator}arm-accton-as4610-30t.dtb"
         ;;
     "4610-30P"*)
-        configuration="#conf@arm-accton-as4610-30p.dtb"
+        configuration="#conf${separator}arm-accton-as4610-30p.dtb"
         ;;
     "4610-54T"*)
-        configuration="#conf@arm-accton-as4610-54t.dtb"
+        configuration="#conf${separator}arm-accton-as4610-54t.dtb"
         ;;
     "4610-54P"*)
-        configuration="#conf@arm-accton-as4610-54p.dtb"
+        configuration="#conf${separator}arm-accton-as4610-54p.dtb"
         ;;
     *)
         echo "Unknown platform \"$platform\", using default configuration"


### PR DESCRIPTION
Yocto upstream changed the way they name the fit nodes, replacing the @
with a -. This causes our bootscript to fail, since the referenced
configuration conf@... does not exist anymore.

Unfortunately they did not backport it (yet?) to warrior, which we still
support. So let's detect the naming at runtime and set the boot
arguments accordingly.

Adapts to upstream change https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?h=dunfell&id=ab6b5e97cebe19938baa403da6307ca320294b3a

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>