### PR TITLE
accton-as7726-32x: add platform.conf

### DIFF
--- a/bisdn/machine/accton/accton-as7726-32x/platform.conf
+++ b/bisdn/machine/accton/accton-as7726-32x/platform.conf
@@ -1,0 +1,3 @@
+GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200n8"
+GRUB_SERIAL_COMMAND="serial --port=0x3f8 --speed=115200 --word=8 --parity=no --stop=1"
+EXTRA_CMDLINE_LINUX="nopat"


### PR DESCRIPTION
Fairly simply config, only extra option is nopat (taken from
https://github.com/opencomputeproject/OpenNetworkLinux/blob/master/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/lib/x86-64-accton-as7726-32x-r0.yml).

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>