### PR TITLE
accton-as5835-54x: add platform.conf

### DIFF
--- a/bisdn/machine/accton/accton-as5835-54x/platform.conf
+++ b/bisdn/machine/accton/accton-as5835-54x/platform.conf
@@ -1,0 +1,3 @@
+GRUB_CMDLINE_LINUX="console=tty0 console=ttyS0,115200n8"
+GRUB_SERIAL_COMMAND="serial --port=0x3f8 --speed=115200 --word=8 --parity=no --stop=1"
+EXTRA_CMDLINE_LINUX="nopat intel_iommu=off"


### PR DESCRIPTION
Based on accton-as7726-32x/platform.conf, extra flags taken from
https://github.com/opencomputeproject/OpenNetworkLinux.git
        commit 6a5e4179ec72d03ece986cac65a3b733bb61aef7
        packages/platforms/accton/x86-64/as5835-54x/
        platform-config/r0/src/lib/x86-64-accton-as5835-54x-r0.yml

Signed-off-by: Roger Luethi <roger.luethi@bisdn.de>