### PR TITLE
backup: make sure default sudoers backup files are ignored

### DIFF
--- a/bisdn/installer/lib/backup.sh
+++ b/bisdn/installer/lib/backup.sh
@@ -7,7 +7,6 @@
 
 SYSTEM_BACKUP_FILE="etc/default/system-backup.txt"
 USER_BACKUP_FILE="etc/default/user-backup.txt"
-BACKUP_SUFFIX="-default"
 
 # $1 src $2 dest
 cp_path_with_attr() {
@@ -153,6 +152,16 @@ restore_backup()
         [ -f "$2/$basefile" ] || continue
         # nothing to do if they are the same
         cmp -s "$file" "$2/$basefile" && continue
+
+	case "$basefile" in
+		"etc/sudoers.d/"*)
+			# sudo only ignores files with . or ending in ~
+			BACKUP_SUFFIX=".default"
+			;;
+		*)
+			BACKUP_SUFFIX="-default"
+			;;
+	esac
 
 	[ -n "$DEBUG" ] && echo "DEBUG: $2/$basefile is different, creating backup as $basefile$BACKUP_SUFFIX" >&2
 


### PR DESCRIPTION
Sudo has special rules for the filename to be ignored, only files with
names ending in ~ (like created by vim) or files with a . in the name
are ignored.

So add a check for the path of the file and make sure we use .default
instead of -default for files in /etc/sudoers.d/.

Fixes changes in /etc/sudoers.d/basebox not sticking through
sysupgrades, due to the basebox-default being followed by sudo.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>